### PR TITLE
Ignore backticks in the sniff

### DIFF
--- a/src/Sniff/QuoteTypeSniff.php
+++ b/src/Sniff/QuoteTypeSniff.php
@@ -30,6 +30,11 @@ final class QuoteTypeSniff implements SniffInterface
     {
         $token = $file->get($stack_ptr);
 
+        // Ignore backticks
+        if ($token->chars[0] === '`') {
+            return;
+        }
+
         if ($token->chars[0] !== $this->quote || $token->chars[strlen($token->chars) - 1] !== $this->quote) {
             $file->addViolation(
                 sprintf('Text should use %s as quotes.', $this->quote),

--- a/src/Sniff/QuoteTypeSniff.php
+++ b/src/Sniff/QuoteTypeSniff.php
@@ -30,7 +30,8 @@ final class QuoteTypeSniff implements SniffInterface
     {
         $token = $file->get($stack_ptr);
 
-        // Ignore backticks
+        // Ignore backticks since it is inline JavaScript.
+        // @see https://www.bennadel.com/blog/2638-executing-javascript-in-the-less-css-precompiler.htm
         if ($token->chars[0] === '`') {
             return;
         }

--- a/test/Sniff/fixtures/quotes.less
+++ b/test/Sniff/fixtures/quotes.less
@@ -4,3 +4,4 @@
 .bad {
     background-image: url('/foo.com');
 }
+@cache-version: `( new Date() ).getTime()`;


### PR DESCRIPTION
Ignore backticks in the sniff. This is special kind of string which evaluates javascript and should be skipped for the quote sniff.