### PR TITLE
Give input options mandatory values when passed to the sniff command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "license":     "MIT",
     "require": {
         "php":                      ">=7.1",
+        "ext-json":                 "*",
         "symfony/console":          "^3.3||^4.0",
-        "yannickl88/css-tokenizer": "^1.1.1",
-        "ext-json": "*"
+        "yannickl88/css-tokenizer": "^1.1.1"
     },
     "require-dev": {
         "hostnet/phpcs-tool": "^8.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php":                      ">=7.1",
         "symfony/console":          "^3.3||^4.0",
-        "yannickl88/css-tokenizer": "^1.1.1"
+        "yannickl88/css-tokenizer": "^1.1.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "hostnet/phpcs-tool": "^8.0.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite name="all">
+        <testsuite name="CSS Sniffer Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="all">
             <directory>./test</directory>
         </testsuite>
     </testsuites>

--- a/src/Command/SniffCommand.php
+++ b/src/Command/SniffCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class SniffCommand extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('sniff')
@@ -57,13 +57,13 @@ final class SniffCommand extends Command
             ->setDescription('Sniffs the given input file and returns the result.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $standard = Standard::loadFromXmlFile($this->guessStandard($input->getOption('standard')));
 
         if ($input->getOption('stdin')) {
             // use the first file passed as the file name.
-            $file = !empty($input->getArgument('files')) ? current($input->getArgument('files')) : 'stdin';
+            $file = !empty($input->getArgument('files')) ? \current($input->getArgument('files')) : 'stdin';
 
             $config = new StdinConfiguration($file);
         } elseif ($input->hasArgument('files') && !empty($input->getArgument('files'))) {
@@ -108,12 +108,12 @@ final class SniffCommand extends Command
             return $standard;
         }
 
-        if (file_exists('csssniff.xml')) {
-            return realpath('csssniff.xml');
+        if (\file_exists('csssniff.xml')) {
+            return \realpath('csssniff.xml');
         }
 
-        if (file_exists('csssniff.xml.dist')) {
-            return realpath('csssniff.xml.dist');
+        if (\file_exists('csssniff.xml.dist')) {
+            return \realpath('csssniff.xml.dist');
         }
 
         return 'Hostnet';

--- a/src/Command/SniffCommand.php
+++ b/src/Command/SniffCommand.php
@@ -30,14 +30,14 @@ final class SniffCommand extends Command
             ->addOption(
                 'format',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Type of output format, default: console',
                 'console'
             )
             ->addOption(
                 'standard',
                 's',
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Code Standard to use, by default the Hostnet standard is used. This is the path to the xml file.'
             )
             ->addOption(

--- a/test/Command/SniffCommandTest.php
+++ b/test/Command/SniffCommandTest.php
@@ -112,7 +112,7 @@ class SniffCommandTest extends TestCase
 
     public function testRunWithEmptyFormatThrowsException(): void
     {
-        $input = new StringInput('--format');
+        $input  = new StringInput('--format');
         $output = new NullOutput();
 
         $this->expectException(RuntimeException::class);
@@ -123,7 +123,7 @@ class SniffCommandTest extends TestCase
 
     public function testRunWithEmptyStandardThrowsException(): void
     {
-        $input = new StringInput('--standard');
+        $input  = new StringInput('--standard');
         $output = new NullOutput();
 
         $this->expectException(RuntimeException::class);

--- a/test/Command/SniffCommandTest.php
+++ b/test/Command/SniffCommandTest.php
@@ -7,8 +7,11 @@ declare(strict_types=1);
 namespace Hostnet\Component\CssSniff\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * @covers \Hostnet\Component\CssSniff\Command\SniffCommand
@@ -105,5 +108,27 @@ class SniffCommandTest extends TestCase
             '"unclosed"' . PHP_EOL,
             $output->fetch()
         );
+    }
+
+    public function testRunWithEmptyFormatThrowsException(): void
+    {
+        $input = new StringInput('--format');
+        $output = new NullOutput();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('option requires a value');
+
+        $this->sniff_command->run($input, $output);
+    }
+
+    public function testRunWithEmptyStandardThrowsException(): void
+    {
+        $input = new StringInput('--standard');
+        $output = new NullOutput();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('option requires a value');
+
+        $this->sniff_command->run($input, $output);
     }
 }

--- a/test/Command/SniffCommandTest.php
+++ b/test/Command/SniffCommandTest.php
@@ -23,12 +23,12 @@ class SniffCommandTest extends TestCase
      */
     private $sniff_command;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->sniff_command = new SniffCommand();
     }
 
-    public function testExecuteStandardConfig()
+    public function testExecuteStandardConfig(): void
     {
         $input  = new ArrayInput([]);
         $output = new BufferedOutput();
@@ -37,11 +37,11 @@ class SniffCommandTest extends TestCase
 
         self::assertEquals(
             "\n",
-            trim($output->fetch()) . "\n"
+            \trim($output->fetch()) . "\n"
         );
     }
 
-    public function testExecuteConsoleOutput()
+    public function testExecuteConsoleOutput(): void
     {
         $input  = new ArrayInput(['files' => [__DIR__ . '/test.less']]);
         $output = new BufferedOutput();
@@ -49,12 +49,12 @@ class SniffCommandTest extends TestCase
         $this->sniff_command->run($input, $output);
 
         self::assertEquals(
-            str_replace('{{FILE}}', __DIR__ . '/test.less', file_get_contents(__DIR__ . '/output.console.txt')),
-            trim($output->fetch()) . "\n"
+            \str_replace('{{FILE}}', __DIR__ . '/test.less', \file_get_contents(__DIR__ . '/output.console.txt')),
+            \trim($output->fetch()) . "\n"
         );
     }
 
-    public function testExecuteJsonOutput()
+    public function testExecuteJsonOutput(): void
     {
         $input  = new ArrayInput(['--format' => 'json', 'files' => [__DIR__ . '/test.less']]);
         $output = new BufferedOutput();
@@ -62,16 +62,16 @@ class SniffCommandTest extends TestCase
         $this->sniff_command->run($input, $output);
 
         self::assertEquals(
-            str_replace(
+            \str_replace(
                 '{{FILE}}',
-                json_encode(__DIR__ . '/test.less'),
-                file_get_contents(__DIR__ . '/output.json.txt')
+                \json_encode(__DIR__ . '/test.less'),
+                \file_get_contents(__DIR__ . '/output.json.txt')
             ),
-            trim($output->fetch()) . "\n"
+            \trim($output->fetch()) . "\n"
         );
     }
 
-    public function testExecuteCheckstyleOutput()
+    public function testExecuteCheckstyleOutput(): void
     {
         $input  = new ArrayInput(['--format' => 'checkstyle', 'files' => [__DIR__ . '/test.less']]);
         $output = new BufferedOutput();
@@ -79,12 +79,12 @@ class SniffCommandTest extends TestCase
         $this->sniff_command->run($input, $output);
 
         self::assertEquals(
-            str_replace('{{FILE}}', __DIR__ . '/test.less', file_get_contents(__DIR__ . '/output.checkstyle.txt')),
-            trim($output->fetch()) . "\n"
+            \str_replace('{{FILE}}', __DIR__ . '/test.less', \file_get_contents(__DIR__ . '/output.checkstyle.txt')),
+            \trim($output->fetch()) . "\n"
         );
     }
 
-    public function testExecuteEmptyInput()
+    public function testExecuteEmptyInput(): void
     {
         $input  = new ArrayInput(['--format' => 'json', 'files' => [__DIR__ . '/empty.less']]);
         $output = new BufferedOutput();
@@ -97,7 +97,7 @@ class SniffCommandTest extends TestCase
         );
     }
 
-    public function testExecuteErrorInput()
+    public function testExecuteErrorInput(): void
     {
         $input  = new ArrayInput(['--format' => 'json', 'files' => [__DIR__ . '/error.less']]);
         $output = new BufferedOutput();


### PR DESCRIPTION
The options themselves will remain optional, however when passing them without a value (ie. `sniff --format`, without specifying a format) a RuntimeException is thrown, indicating that the option requires a value.

Additionally, some small style updates are applied, such as return type- and scope declarations and a (mandatory) name attribute for the testsuite tag in the phpunit configuration.